### PR TITLE
Added better path information for failure states of oneOf and allOf.

### DIFF
--- a/yaml-validator/src/error.rs
+++ b/yaml-validator/src/error.rs
@@ -11,7 +11,7 @@ pub type PathVec<'a> = Vec<PathSegment<'a>>;
 #[cfg(feature = "smallvec")]
 macro_rules! path{
     ( $( $x:expr ),* ) => {
-        smallvec![
+        smallvec::smallvec![
             $(crate::error::PathSegment::from($x),)*
         ]
     }

--- a/yaml-validator/src/modifiers/not.rs
+++ b/yaml-validator/src/modifiers/not.rs
@@ -48,9 +48,6 @@ mod tests {
     use super::*;
     use crate::utils::load_simple;
 
-    #[cfg(feature = "smallvec")]
-    use smallvec::smallvec;
-
     #[test]
     fn not_from_yaml() {
         SchemaNot::try_from(&load_simple(
@@ -111,7 +108,7 @@ mod tests {
             SchemaErrorKind::ValidationError {
                 error: "validation inversion failed because inner result matched"
             }
-            .with_path(path!["not"])
+            .with_path_name("not")
         );
     }
 

--- a/yaml-validator/src/types/array.rs
+++ b/yaml-validator/src/types/array.rs
@@ -226,9 +226,6 @@ mod tests {
     use crate::utils::load_simple;
     use crate::SchemaArray;
 
-    #[cfg(feature = "smallvec")]
-    use smallvec::smallvec;
-
     #[test]
     fn from_yaml() {
         SchemaArray::try_from(&load_simple(
@@ -254,7 +251,7 @@ mod tests {
                 expected: "hash",
                 actual: "array"
             }
-            .with_path(path!["items"])
+            .with_path_name("items")
             .into(),
         );
     }
@@ -616,17 +613,17 @@ mod tests {
                         expected: "integer",
                         actual: "string"
                     }
-                    .with_path(path![0]),
+                    .with_path_index(0),
                     SchemaErrorKind::WrongType {
                         expected: "integer",
                         actual: "string"
                     }
-                    .with_path(path![4]),
+                    .with_path_index(4),
                     SchemaErrorKind::WrongType {
                         expected: "integer",
                         actual: "hash"
                     }
-                    .with_path(path![6])
+                    .with_path_index(6)
                 ]
             }
             .into()

--- a/yaml-validator/src/types/hash.rs
+++ b/yaml-validator/src/types/hash.rs
@@ -68,9 +68,6 @@ mod tests {
     use crate::utils::load_simple;
     use crate::SchemaHash;
 
-    #[cfg(feature = "smallvec")]
-    use smallvec::smallvec;
-
     #[test]
     fn from_yaml() {
         SchemaHash::try_from(&load_simple(
@@ -96,7 +93,7 @@ mod tests {
                 expected: "hash",
                 actual: "array"
             }
-            .with_path(path!["items"])
+            .with_path_name("items")
             .into(),
         );
     }
@@ -210,7 +207,7 @@ mod tests {
                 expected: "integer",
                 actual: "string"
             }
-            .with_path(path![1])
+            .with_path_index(1)
         );
     }
 }

--- a/yaml-validator/src/types/object.rs
+++ b/yaml-validator/src/types/object.rs
@@ -335,12 +335,12 @@ mod tests {
                         expected: "string",
                         actual: "integer"
                     }
-                    .with_path(path!["hello"]),
+                    .with_path_name("hello"),
                     SchemaErrorKind::WrongType {
                         expected: "integer",
                         actual: "string"
                     }
-                    .with_path(path!["world"])
+                    .with_path_name("world")
                 ]
             }
             .into()

--- a/yaml-validator/src/types/string.rs
+++ b/yaml-validator/src/types/string.rs
@@ -128,9 +128,6 @@ mod tests {
     use crate::utils::load_simple;
     use crate::SchemaString;
 
-    #[cfg(feature = "smallvec")]
-    use smallvec::smallvec;
-
     #[test]
     fn from_yaml() {
         SchemaString::try_from(&load_simple("type: string")).unwrap();
@@ -203,7 +200,7 @@ mod tests {
             SchemaErrorKind::MalformedField {
                 error: "must be a non-negative integer value".into()
             }
-            .with_path(path!["maxLength"])
+            .with_path_name("maxLength")
         );
     }
 
@@ -221,7 +218,7 @@ mod tests {
                 actual: "real",
                 expected: "integer"
             }
-            .with_path(path!["minLength"])
+            .with_path_name("minLength")
         );
     }
 


### PR DESCRIPTION
Replaced use of path! macro in places where it was not necessary, since it was only a single-element path

Fixed path! macro to use absolute path to `smallvec::smallvec!` macro if the feature is enabled,
instead of relative paths which fails unless `smallvec!` is already in scope, such as in tests.

Fixes #26