### PR TITLE
Undo the appending of validation paths to the actual document paths.

### DIFF
--- a/examples/branching/schema.yaml
+++ b/examples/branching/schema.yaml
@@ -1,0 +1,30 @@
+---
+uri: must-contain-letter
+schema:
+  type: string
+  pattern: .*[a-zA-Z].*
+
+---
+uri: must-contain-number
+schema:
+  type: string
+  pattern: .*[0-9].*
+
+---
+uri: must-contain-letter-and-number
+schema:
+  allOf:
+    - $ref: must-contain-letter
+    - $ref: must-contain-number
+
+---
+uri: user-list
+schema:
+  type: array
+  items:
+    type: object
+    items:
+      username:
+        type: string
+      password:
+        $ref: must-contain-letter-and-number

--- a/examples/branching/usernames.yaml
+++ b/examples/branching/usernames.yaml
@@ -1,0 +1,9 @@
+---
+- username: mulder
+  password: trustno1
+
+- username: neo
+  password: hunter2
+
+- username: karen
+  password: password

--- a/yaml-validator-cli/src/main.rs
+++ b/yaml-validator-cli/src/main.rs
@@ -189,6 +189,24 @@ mod tests {
     }
 
     #[test]
+    fn test_branching_examples() {
+        assert_eq!(
+            actual_main(Opt {
+                schemas: vec!["../examples/branching/schema.yaml".into()],
+                files: vec!["../examples/branching/usernames.yaml".into()],
+                uri: "user-list".into(),
+            })
+            .unwrap_err(),
+            Error::ValidationError(
+                "../examples/branching/usernames.yaml:
+#[2].password: special requirements for field not met: supplied value does not match regex pattern for field
+"
+                .into()
+            )
+        );
+    }
+
+    #[test]
     fn test_non_existent_schema_file() {
         assert_eq!(
             actual_main(Opt {

--- a/yaml-validator/src/modifiers/all_of.rs
+++ b/yaml-validator/src/modifiers/all_of.rs
@@ -1,4 +1,4 @@
-use crate::error::{add_path_index, add_path_name, condense_errors, SchemaError, SchemaErrorKind};
+use crate::error::{add_path_name, condense_errors, SchemaError, SchemaErrorKind};
 use crate::utils::YamlUtils;
 use crate::{Context, PropertyType, Validate};
 use std::convert::TryFrom;
@@ -45,12 +45,7 @@ impl<'yaml, 'schema: 'yaml> Validate<'yaml, 'schema> for SchemaAllOf<'schema> {
             .items
             .iter()
             .enumerate()
-            .map(|(id, schema)| {
-                schema
-                    .validate(ctx, yaml)
-                    .map_err(add_path_name("allOf"))
-                    .map_err(add_path_index(id))
-            })
+            .map(|(_, schema)| schema.validate(ctx, yaml))
             .filter(Result::is_err)
             .collect();
 
@@ -134,7 +129,7 @@ mod tests {
             SchemaErrorKind::ValidationError {
                 error: "string length is less than minLength"
             }
-            .with_path(path!["allOf", 0])
+            .into()
         );
     }
 }

--- a/yaml-validator/src/modifiers/any_of.rs
+++ b/yaml-validator/src/modifiers/any_of.rs
@@ -44,7 +44,8 @@ impl<'yaml, 'schema: 'yaml> Validate<'yaml, 'schema> for SchemaAnyOf<'schema> {
         let (valid, errs): (Vec<_>, Vec<_>) = self
             .items
             .iter()
-            .map(|schema| schema.validate(ctx, yaml).map_err(add_path_name("anyOf")))
+            .enumerate()
+            .map(|(_, schema)| schema.validate(ctx, yaml))
             .partition(Result::is_ok);
 
         if valid.is_empty() {

--- a/yaml-validator/src/modifiers/one_of.rs
+++ b/yaml-validator/src/modifiers/one_of.rs
@@ -1,4 +1,4 @@
-use crate::error::{add_path_index, add_path_name, condense_errors, SchemaError, SchemaErrorKind};
+use crate::error::{add_path_name, condense_errors, SchemaError, SchemaErrorKind};
 use crate::utils::YamlUtils;
 use crate::{Context, PropertyType, Validate};
 use std::convert::TryFrom;
@@ -45,13 +45,7 @@ impl<'yaml, 'schema: 'yaml> Validate<'yaml, 'schema> for SchemaOneOf<'schema> {
             .items
             .iter()
             .enumerate()
-            .map(|(id, schema)| {
-                schema
-                    .validate(ctx, yaml)
-                    .map(|valid| (valid, id))
-                    .map_err(add_path_name("oneOf"))
-                    .map_err(add_path_index(id))
-            })
+            .map(|(id, schema)| schema.validate(ctx, yaml).map(|valid| (valid, id)))
             .partition(Result::is_ok);
 
         match valid.len() {


### PR DESCRIPTION
Undo the appending of validation paths to the actual document paths, I got the two mixed up. See #32 for discussion.

Add a new example 'branching' for testing out the allOf keyword.