### PR TITLE
Separate Schema and Validation errors.

### DIFF
--- a/examples/password/passwords.yaml
+++ b/examples/password/passwords.yaml
@@ -1,0 +1,9 @@
+---
+- username: mulder
+  password: trustno1
+
+- username: neo
+  password: hunter2
+
+- username: karen
+  password: password

--- a/examples/password/schema.yaml
+++ b/examples/password/schema.yaml
@@ -1,0 +1,30 @@
+---
+uri: must-contain-letter
+schema:
+  type: string
+  pattern: .*[a-zA-Z].*
+
+---
+uri: must-contain-number
+schema:
+  type: string
+  pattern: .*[0-9].*
+
+---
+uri: must-contain-letter-and-number
+schema:
+  allOf:
+    - $ref: must-contain-letter
+    - $ref: must-contain-number
+
+---
+uri: user-list
+schema:
+  type: array
+  items:
+    type: object
+    items:
+      username:
+        type: string
+      password:
+        $ref: must-contain-letter-and-number

--- a/yaml-validator-cli/Cargo.toml
+++ b/yaml-validator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaml-validator-cli"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Mathias Pius <contact@pius.io>"]
 edition = "2018"
 description = "A command-line interface to the yaml-validator library"
@@ -10,5 +10,5 @@ license = "MIT"
 keywords = ["YAML", "validation", "schema"]
 
 [dependencies]
-yaml-validator = { "path" = "../yaml-validator", version = "0.1.0" }
-structopt = "0.3.21"
+yaml-validator = { "path" = "../yaml-validator", version = "0.2.0" }
+structopt = "0.3.26"

--- a/yaml-validator-cli/src/error.rs
+++ b/yaml-validator-cli/src/error.rs
@@ -2,36 +2,36 @@ use yaml_validator::{yaml_rust::ScanError, SchemaError};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
-    FileError(String),
-    ValidationError(String),
-    YamlError(String),
+    File(String),
+    Validation(String),
+    Yaml(String),
     Multiple(Vec<Error>),
 }
 
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
-        Error::FileError(format!("{}", e))
+        Error::File(format!("{}", e))
     }
 }
 
 impl From<ScanError> for Error {
     fn from(e: ScanError) -> Self {
-        Error::YamlError(format!("{}", e))
+        Error::Yaml(format!("{}", e))
     }
 }
 
 impl<'a> From<SchemaError<'a>> for Error {
     fn from(e: SchemaError<'a>) -> Self {
-        Error::ValidationError(format!("{}", e))
+        Error::Validation(format!("{}", e))
     }
 }
 
 impl<'a> std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::FileError(e) => write!(f, "{}", e),
-            Error::ValidationError(e) => write!(f, "{}", e),
-            Error::YamlError(e) => write!(f, "{}", e),
+            Error::File(e) => write!(f, "{}", e),
+            Error::Validation(e) => write!(f, "{}", e),
+            Error::Yaml(e) => write!(f, "{}", e),
             Error::Multiple(e) => {
                 for err in e {
                     write!(f, "{}", err)?;

--- a/yaml-validator/Cargo.toml
+++ b/yaml-validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaml-validator"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Mathias Pius <contact@pius.io>"]
 edition = "2018"
 description = "A library for validating YAML against YAML-defined schemas"
@@ -10,10 +10,10 @@ license = "MIT"
 keywords = ["YAML", "validation", "schema"]
 
 [dependencies]
-yaml-rust = "0.4.4"
-thiserror = "1.0.22"
-regex = { "version" = "1.4.2", optional = true }
-smallvec = { "version" = "1.5.1", optional = true }
+yaml-rust = "0.4.5"
+thiserror = "1.0.30"
+regex = { "version" = "1.5.4", optional = true }
+smallvec = { "version" = "1.8.0", optional = true }
 
 [features]
 default = ["regex", "smallvec"]

--- a/yaml-validator/src/breadcrumb.rs
+++ b/yaml-validator/src/breadcrumb.rs
@@ -1,0 +1,79 @@
+#![macro_use]
+
+#[cfg(feature = "smallvec")]
+pub type BreadcrumbSegmentVec<'a> = smallvec::SmallVec<[BreadcrumbSegment<'a>; 8]>;
+#[cfg(not(feature = "smallvec"))]
+pub type BreadcrumbSegmentVec<'a> = Vec<BreadcrumbSegment<'a>>;
+
+#[cfg(test)]
+#[cfg(feature = "smallvec")]
+macro_rules! breadcrumb{
+    ( $( $x:expr ),* ) => {
+        smallvec::smallvec![
+            $(crate::breadcrumb::BreadcrumbSegment::from($x),)*
+        ]
+    }
+}
+
+#[cfg(test)]
+#[cfg(not(feature = "smallvec"))]
+macro_rules! breadcrumb{
+    ( $( $x:expr ),* ) => {
+        vec![
+            $(crate::breadcrumb::BreadcrumbSegment::from($x),)*
+        ]
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum BreadcrumbSegment<'a> {
+    Name(&'a str),
+    Index(usize),
+}
+
+impl<'a> From<&'a str> for BreadcrumbSegment<'a> {
+    fn from(name: &'a str) -> Self {
+        BreadcrumbSegment::Name(name)
+    }
+}
+
+impl<'a> From<usize> for BreadcrumbSegment<'a> {
+    fn from(index: usize) -> Self {
+        BreadcrumbSegment::Index(index)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Breadcrumb<'a> {
+    segments: BreadcrumbSegmentVec<'a>,
+}
+
+impl<'a> Breadcrumb<'a> {
+    pub fn new(segments: BreadcrumbSegmentVec<'a>) -> Self {
+        Breadcrumb { segments }
+    }
+    pub fn push(&mut self, segment: BreadcrumbSegment<'a>) {
+        self.segments.push(segment);
+    }
+}
+
+impl<'a> std::fmt::Display for Breadcrumb<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for segment in self.segments.iter().rev() {
+            match segment {
+                BreadcrumbSegment::Name(name) => write!(f, ".{}", name)?,
+                BreadcrumbSegment::Index(index) => write!(f, "[{}]", index)?,
+            };
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> Default for Breadcrumb<'a> {
+    fn default() -> Self {
+        Breadcrumb {
+            segments: BreadcrumbSegmentVec::new(),
+        }
+    }
+}

--- a/yaml-validator/src/errors/mod.rs
+++ b/yaml-validator/src/errors/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod schema;
+
+pub use schema::{SchemaError, SchemaErrorKind};

--- a/yaml-validator/src/errors/mod.rs
+++ b/yaml-validator/src/errors/mod.rs
@@ -1,3 +1,5 @@
 pub(crate) mod schema;
+pub(crate) mod validation;
 
 pub use schema::{SchemaError, SchemaErrorKind};
+pub use validation::{ValidationError, ValidationErrorKind};

--- a/yaml-validator/src/errors/mod.rs
+++ b/yaml-validator/src/errors/mod.rs
@@ -7,7 +7,7 @@ pub use validation::{ValidationError, ValidationErrorKind};
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq, Eq)]
-pub enum YamlError<'a> {
+pub enum GenericError<'a> {
     #[error("wrong type, expected {expected} got {actual}")]
     WrongType {
         expected: &'static str,
@@ -20,5 +20,5 @@ pub enum YamlError<'a> {
     #[error("malformed field: {error}")]
     MalformedField { error: String },
     #[error("multiple errors were encountered: {errors:?}")]
-    Multiple { errors: Vec<YamlError<'a>> },
+    Multiple { errors: Vec<GenericError<'a>> },
 }

--- a/yaml-validator/src/errors/mod.rs
+++ b/yaml-validator/src/errors/mod.rs
@@ -3,3 +3,22 @@ pub(crate) mod validation;
 
 pub use schema::{SchemaError, SchemaErrorKind};
 pub use validation::{ValidationError, ValidationErrorKind};
+
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum YamlError<'a> {
+    #[error("wrong type, expected {expected} got {actual}")]
+    WrongType {
+        expected: &'static str,
+        actual: &'a str,
+    },
+    #[error("field '{field}' missing")]
+    FieldMissing { field: &'a str },
+    #[error("field '{field}' is not specified in the schema")]
+    ExtraField { field: &'a str },
+    #[error("malformed field: {error}")]
+    MalformedField { error: String },
+    #[error("multiple errors were encountered: {errors:?}")]
+    Multiple { errors: Vec<YamlError<'a>> },
+}

--- a/yaml-validator/src/errors/mod.rs
+++ b/yaml-validator/src/errors/mod.rs
@@ -17,8 +17,6 @@ pub enum GenericError<'a> {
     FieldMissing { field: &'a str },
     #[error("field '{field}' is not specified in the schema")]
     ExtraField { field: &'a str },
-    #[error("malformed field: {error}")]
-    MalformedField { error: String },
     #[error("multiple errors were encountered: {errors:?}")]
     Multiple { errors: Vec<GenericError<'a>> },
 }

--- a/yaml-validator/src/errors/schema.rs
+++ b/yaml-validator/src/errors/schema.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use crate::breadcrumb::{Breadcrumb, BreadcrumbSegment, BreadcrumbSegmentVec};
 
-use super::YamlError;
+use super::GenericError;
 
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum SchemaErrorKind<'a> {
@@ -112,16 +112,16 @@ impl<'a> From<SchemaErrorKind<'a>> for SchemaError<'a> {
     }
 }
 
-impl<'a> From<YamlError<'a>> for SchemaErrorKind<'a> {
-    fn from(e: YamlError<'a>) -> Self {
+impl<'a> From<GenericError<'a>> for SchemaErrorKind<'a> {
+    fn from(e: GenericError<'a>) -> Self {
         match e {
-            YamlError::WrongType { expected, actual } => {
+            GenericError::WrongType { expected, actual } => {
                 SchemaErrorKind::WrongType { expected, actual }
             }
-            YamlError::FieldMissing { field } => SchemaErrorKind::FieldMissing { field },
-            YamlError::ExtraField { field } => SchemaErrorKind::ExtraField { field },
-            YamlError::MalformedField { error } => SchemaErrorKind::MalformedField { error },
-            YamlError::Multiple { errors } => SchemaErrorKind::Multiple {
+            GenericError::FieldMissing { field } => SchemaErrorKind::FieldMissing { field },
+            GenericError::ExtraField { field } => SchemaErrorKind::ExtraField { field },
+            GenericError::MalformedField { error } => SchemaErrorKind::MalformedField { error },
+            GenericError::Multiple { errors } => SchemaErrorKind::Multiple {
                 errors: errors
                     .into_iter()
                     .map(SchemaErrorKind::from)
@@ -132,8 +132,8 @@ impl<'a> From<YamlError<'a>> for SchemaErrorKind<'a> {
     }
 }
 
-impl<'a> From<YamlError<'a>> for SchemaError<'a> {
-    fn from(e: YamlError<'a>) -> Self {
+impl<'a> From<GenericError<'a>> for SchemaError<'a> {
+    fn from(e: GenericError<'a>) -> Self {
         SchemaErrorKind::from(e).into()
     }
 }

--- a/yaml-validator/src/errors/schema.rs
+++ b/yaml-validator/src/errors/schema.rs
@@ -2,9 +2,8 @@
 
 use thiserror::Error;
 
-use crate::breadcrumb::{Breadcrumb, BreadcrumbSegment, BreadcrumbSegmentVec};
-
 use super::GenericError;
+use crate::breadcrumb::{Breadcrumb, BreadcrumbSegment, BreadcrumbSegmentVec};
 
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum SchemaErrorKind<'a> {
@@ -85,17 +84,6 @@ impl<'a> SchemaErrorKind<'a> {
         let mut err: SchemaError = self.into();
         err.state.push(BreadcrumbSegment::Index(index));
         err
-    }
-}
-
-pub fn schema_optional<'a, T>(
-    default: T,
-) -> impl FnOnce(SchemaError<'a>) -> Result<T, SchemaError<'a>> {
-    move |err: SchemaError<'a>| -> Result<T, SchemaError<'a>> {
-        match err.kind {
-            SchemaErrorKind::FieldMissing { .. } => Ok(default),
-            _ => Err(err),
-        }
     }
 }
 

--- a/yaml-validator/src/errors/schema.rs
+++ b/yaml-validator/src/errors/schema.rs
@@ -116,7 +116,6 @@ impl<'a> From<GenericError<'a>> for SchemaErrorKind<'a> {
             }
             GenericError::FieldMissing { field } => SchemaErrorKind::FieldMissing { field },
             GenericError::ExtraField { field } => SchemaErrorKind::ExtraField { field },
-            GenericError::MalformedField { error } => SchemaErrorKind::MalformedField { error },
             GenericError::Multiple { errors } => SchemaErrorKind::Multiple {
                 errors: errors
                     .into_iter()

--- a/yaml-validator/src/errors/schema.rs
+++ b/yaml-validator/src/errors/schema.rs
@@ -96,6 +96,12 @@ impl<'a> From<SchemaErrorKind<'a>> for SchemaError<'a> {
     }
 }
 
+impl<'a> From<Vec<SchemaError<'a>>> for SchemaError<'a> {
+    fn from(errors: Vec<SchemaError<'a>>) -> Self {
+        SchemaErrorKind::Multiple { errors }.into()
+    }
+}
+
 impl<'a> From<GenericError<'a>> for SchemaErrorKind<'a> {
     fn from(e: GenericError<'a>) -> Self {
         match e {
@@ -118,22 +124,6 @@ impl<'a> From<GenericError<'a>> for SchemaErrorKind<'a> {
 impl<'a> From<GenericError<'a>> for SchemaError<'a> {
     fn from(e: GenericError<'a>) -> Self {
         SchemaErrorKind::from(e).into()
-    }
-}
-
-pub fn condense_schema_errors<'a, T>(
-    iter: &mut dyn Iterator<Item = Result<T, SchemaError<'a>>>,
-) -> Result<(), SchemaError<'a>> {
-    let mut errors: Vec<SchemaError> = iter.filter_map(Result::err).collect();
-
-    if !errors.is_empty() {
-        if errors.len() == 1 {
-            Err(errors.pop().unwrap())
-        } else {
-            Err(SchemaErrorKind::Multiple { errors }.into())
-        }
-    } else {
-        Ok(())
     }
 }
 

--- a/yaml-validator/src/errors/schema.rs
+++ b/yaml-validator/src/errors/schema.rs
@@ -47,6 +47,20 @@ impl<'a> SchemaError<'a> {
 
         Ok(())
     }
+
+    pub fn add_path_name(path: &'a str) -> impl Fn(SchemaError<'a>) -> SchemaError<'a> {
+        move |mut err: SchemaError<'a>| -> SchemaError<'a> {
+            err.state.push(BreadcrumbSegment::Name(path));
+            err
+        }
+    }
+
+    pub fn add_path_index(index: usize) -> impl Fn(SchemaError<'a>) -> SchemaError<'a> {
+        move |mut err: SchemaError<'a>| -> SchemaError<'a> {
+            err.state.push(BreadcrumbSegment::Index(index));
+            err
+        }
+    }
 }
 
 impl<'a> std::fmt::Display for SchemaError<'a> {
@@ -71,20 +85,6 @@ impl<'a> SchemaErrorKind<'a> {
 
     pub fn with_path_index(self, index: usize) -> SchemaError<'a> {
         let mut err: SchemaError = self.into();
-        err.state.push(BreadcrumbSegment::Index(index));
-        err
-    }
-}
-
-pub fn add_path_name<'a>(path: &'a str) -> impl Fn(SchemaError<'a>) -> SchemaError<'a> {
-    move |mut err: SchemaError<'a>| -> SchemaError<'a> {
-        err.state.push(BreadcrumbSegment::Name(path));
-        err
-    }
-}
-
-pub fn add_path_index<'a>(index: usize) -> impl Fn(SchemaError<'a>) -> SchemaError<'a> {
-    move |mut err: SchemaError<'a>| -> SchemaError<'a> {
         err.state.push(BreadcrumbSegment::Index(index));
         err
     }

--- a/yaml-validator/src/errors/schema.rs
+++ b/yaml-validator/src/errors/schema.rs
@@ -15,8 +15,6 @@ pub enum SchemaErrorKind<'a> {
     },
     #[error("malformed field: {error}")]
     MalformedField { error: String },
-    #[error("special requirements for field not met: {error}")]
-    ValidationError { error: &'a str },
     #[error("field '{field}' missing")]
     FieldMissing { field: &'a str },
     #[error("field '{field}' is not specified in the schema")]
@@ -25,8 +23,6 @@ pub enum SchemaErrorKind<'a> {
     UnknownType { unknown_type: &'a str },
     #[error("multiple errors were encountered: {errors:?}")]
     Multiple { errors: Vec<SchemaError<'a>> },
-    #[error("schema '{uri}' references was not found")]
-    UnknownSchema { uri: &'a str },
 }
 
 /// A wrapper type around SchemaErrorKind containing path information about where the error occurred.

--- a/yaml-validator/src/errors/validation.rs
+++ b/yaml-validator/src/errors/validation.rs
@@ -9,10 +9,20 @@ pub enum ValidationErrorKind<'a> {
         expected: &'static str,
         actual: &'a str,
     },
-    #[error("multiple validation errors were encountered: {errors:?}")]
+    #[error("malformed field: {error}")]
+    MalformedField { error: String },
+    #[error("special requirements for field not met: {error}")]
+    ValidationError { error: &'a str },
+    #[error("field '{field}' missing")]
+    FieldMissing { field: &'a str },
+    #[error("field '{field}' is not specified in the schema")]
+    ExtraField { field: &'a str },
+    #[error("unknown type specified: {unknown_type}")]
+    UnknownType { unknown_type: &'a str },
+    #[error("multiple errors were encountered: {errors:?}")]
     Multiple { errors: Vec<ValidationError<'a>> },
-    #[error("unknown validation error")]
-    Unknown,
+    #[error("schema '{uri}' references was not found")]
+    UnknownSchema { uri: &'a str },
 }
 
 impl<'a> ValidationErrorKind<'a> {

--- a/yaml-validator/src/errors/validation.rs
+++ b/yaml-validator/src/errors/validation.rs
@@ -11,8 +11,6 @@ pub enum ValidationErrorKind<'a> {
         expected: &'static str,
         actual: &'a str,
     },
-    #[error("malformed field: {error}")]
-    MalformedField { error: String },
     #[error("special requirements for field not met: {error}")]
     ValidationError { error: &'a str },
     #[error("field '{field}' missing")]
@@ -65,7 +63,6 @@ impl<'a> From<GenericError<'a>> for ValidationErrorKind<'a> {
             }
             GenericError::FieldMissing { field } => ValidationErrorKind::FieldMissing { field },
             GenericError::ExtraField { field } => ValidationErrorKind::ExtraField { field },
-            GenericError::MalformedField { error } => ValidationErrorKind::MalformedField { error },
             GenericError::Multiple { errors } => ValidationErrorKind::Multiple {
                 errors: errors
                     .into_iter()

--- a/yaml-validator/src/errors/validation.rs
+++ b/yaml-validator/src/errors/validation.rs
@@ -1,0 +1,87 @@
+use thiserror::Error;
+
+use crate::breadcrumb::{Breadcrumb, BreadcrumbSegment, BreadcrumbSegmentVec};
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum ValidationErrorKind<'a> {
+    #[error("wrong type, expected {expected} got {actual}")]
+    WrongType {
+        expected: &'static str,
+        actual: &'a str,
+    },
+    #[error("multiple validation errors were encountered: {errors:?}")]
+    Multiple { errors: Vec<ValidationError<'a>> },
+    #[error("unknown validation error")]
+    Unknown,
+}
+
+impl<'a> ValidationErrorKind<'a> {
+    pub fn with_path(self, path: BreadcrumbSegmentVec<'a>) -> ValidationError<'a> {
+        ValidationError {
+            kind: self,
+            state: Breadcrumb::new(path),
+        }
+    }
+
+    pub fn with_path_name(self, path: &'a str) -> ValidationError<'a> {
+        let mut err: ValidationError = self.into();
+        err.state.push(BreadcrumbSegment::Name(path));
+        err
+    }
+
+    pub fn with_path_index(self, index: usize) -> ValidationError<'a> {
+        let mut err: ValidationError = self.into();
+        err.state.push(BreadcrumbSegment::Index(index));
+        err
+    }
+}
+
+impl<'a> From<ValidationErrorKind<'a>> for ValidationError<'a> {
+    fn from(kind: ValidationErrorKind<'a>) -> ValidationError<'a> {
+        ValidationError {
+            kind,
+            state: Breadcrumb::default(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ValidationError<'a> {
+    pub kind: ValidationErrorKind<'a>,
+    pub state: Breadcrumb<'a>,
+}
+
+impl<'a> ValidationError<'a> {
+    fn flatten(&self, fmt: &mut std::fmt::Formatter<'_>, root: String) -> std::fmt::Result {
+        match &self.kind {
+            ValidationErrorKind::Multiple { errors } => {
+                for err in errors {
+                    err.flatten(fmt, format!("{}{}", root, self.state))?;
+                }
+            }
+            err => writeln!(fmt, "{}{}: {}", root, self.state, err)?,
+        }
+
+        Ok(())
+    }
+
+    pub fn add_path_name(path: &'a str) -> impl Fn(ValidationError<'a>) -> ValidationError<'a> {
+        move |mut err: ValidationError<'a>| -> ValidationError<'a> {
+            err.state.push(BreadcrumbSegment::Name(path));
+            err
+        }
+    }
+
+    pub fn add_path_index(index: usize) -> impl Fn(ValidationError<'a>) -> ValidationError<'a> {
+        move |mut err: ValidationError<'a>| -> ValidationError<'a> {
+            err.state.push(BreadcrumbSegment::Index(index));
+            err
+        }
+    }
+}
+
+impl<'a> std::fmt::Display for ValidationError<'a> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.flatten(fmt, "#".to_string())
+    }
+}

--- a/yaml-validator/src/errors/validation.rs
+++ b/yaml-validator/src/errors/validation.rs
@@ -55,6 +55,12 @@ impl<'a> From<ValidationErrorKind<'a>> for ValidationError<'a> {
     }
 }
 
+impl<'a> From<Vec<ValidationError<'a>>> for ValidationError<'a> {
+    fn from(errors: Vec<ValidationError<'a>>) -> Self {
+        ValidationErrorKind::Multiple { errors }.into()
+    }
+}
+
 impl<'a> From<GenericError<'a>> for ValidationErrorKind<'a> {
     fn from(e: GenericError<'a>) -> Self {
         match e {
@@ -118,21 +124,5 @@ impl<'a> ValidationError<'a> {
 impl<'a> std::fmt::Display for ValidationError<'a> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.flatten(fmt, "#".to_string())
-    }
-}
-
-pub fn condense_validation_errors<'a, T>(
-    iter: &mut dyn Iterator<Item = Result<T, ValidationError<'a>>>,
-) -> Result<(), ValidationError<'a>> {
-    let mut errors: Vec<ValidationError> = iter.filter_map(Result::err).collect();
-
-    if !errors.is_empty() {
-        if errors.len() == 1 {
-            Err(errors.pop().unwrap())
-        } else {
-            Err(ValidationErrorKind::Multiple { errors }.into())
-        }
-    } else {
-        Ok(())
     }
 }

--- a/yaml-validator/src/errors/validation.rs
+++ b/yaml-validator/src/errors/validation.rs
@@ -136,14 +136,3 @@ pub fn condense_validation_errors<'a, T>(
         Ok(())
     }
 }
-
-pub fn validation_optional<'a, T>(
-    default: T,
-) -> impl FnOnce(ValidationError<'a>) -> Result<T, ValidationError<'a>> {
-    move |err: ValidationError<'a>| -> Result<T, ValidationError<'a>> {
-        match err.kind {
-            ValidationErrorKind::FieldMissing { .. } => Ok(default),
-            _ => Err(err),
-        }
-    }
-}

--- a/yaml-validator/src/errors/validation.rs
+++ b/yaml-validator/src/errors/validation.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 use crate::breadcrumb::{Breadcrumb, BreadcrumbSegment, BreadcrumbSegmentVec};
 
-use super::YamlError;
+use super::GenericError;
 
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ValidationErrorKind<'a> {
@@ -57,16 +57,16 @@ impl<'a> From<ValidationErrorKind<'a>> for ValidationError<'a> {
     }
 }
 
-impl<'a> From<YamlError<'a>> for ValidationErrorKind<'a> {
-    fn from(e: YamlError<'a>) -> Self {
+impl<'a> From<GenericError<'a>> for ValidationErrorKind<'a> {
+    fn from(e: GenericError<'a>) -> Self {
         match e {
-            YamlError::WrongType { expected, actual } => {
+            GenericError::WrongType { expected, actual } => {
                 ValidationErrorKind::WrongType { expected, actual }
             }
-            YamlError::FieldMissing { field } => ValidationErrorKind::FieldMissing { field },
-            YamlError::ExtraField { field } => ValidationErrorKind::ExtraField { field },
-            YamlError::MalformedField { error } => ValidationErrorKind::MalformedField { error },
-            YamlError::Multiple { errors } => ValidationErrorKind::Multiple {
+            GenericError::FieldMissing { field } => ValidationErrorKind::FieldMissing { field },
+            GenericError::ExtraField { field } => ValidationErrorKind::ExtraField { field },
+            GenericError::MalformedField { error } => ValidationErrorKind::MalformedField { error },
+            GenericError::Multiple { errors } => ValidationErrorKind::Multiple {
                 errors: errors
                     .into_iter()
                     .map(ValidationErrorKind::from)
@@ -77,8 +77,8 @@ impl<'a> From<YamlError<'a>> for ValidationErrorKind<'a> {
     }
 }
 
-impl<'a> From<YamlError<'a>> for ValidationError<'a> {
-    fn from(e: YamlError<'a>) -> Self {
+impl<'a> From<GenericError<'a>> for ValidationError<'a> {
+    fn from(e: GenericError<'a>) -> Self {
         ValidationErrorKind::from(e).into()
     }
 }

--- a/yaml-validator/src/lib.rs
+++ b/yaml-validator/src/lib.rs
@@ -13,8 +13,11 @@ mod utils;
 use modifiers::*;
 use types::*;
 
-use errors::{schema::{condense_errors, optional}, ValidationError};
 pub use errors::schema::{SchemaError, SchemaErrorKind};
+use errors::{
+    schema::{condense_schema_errors, schema_optional},
+    ValidationError,
+};
 
 use crate::types::bool::SchemaBool;
 use utils::YamlUtils;
@@ -72,7 +75,7 @@ impl<'schema> TryFrom<&'schema [Yaml]> for Context<'schema> {
             .map(Schema::try_from)
             .partition(Result::is_ok);
 
-        condense_errors(&mut errs.into_iter())?;
+        condense_schema_errors(&mut errs.into_iter())?;
 
         Ok(Context {
             schemas: schemas
@@ -113,16 +116,20 @@ impl<'schema> TryFrom<&'schema Yaml> for PropertyType<'schema> {
 
         if let Some(uri) = yaml
             .lookup("$ref", "string", Yaml::as_str)
+            .map_err(SchemaErrorKind::from)
+            .map_err(SchemaError::from)
             .map(Option::from)
-            .or_else(optional(None))?
+            .or_else(schema_optional(None))?
         {
             return Ok(PropertyType::Reference(SchemaReference { uri }));
         }
 
         if yaml
             .lookup("not", "hash", Option::from)
+            .map_err(SchemaErrorKind::from)
+            .map_err(SchemaError::from)
             .map(Option::from)
-            .or_else(optional(None))?
+            .or_else(schema_optional(None))?
             .is_some()
         {
             return Ok(PropertyType::Not(SchemaNot::try_from(yaml)?));
@@ -130,8 +137,10 @@ impl<'schema> TryFrom<&'schema Yaml> for PropertyType<'schema> {
 
         if yaml
             .lookup("oneOf", "hash", Option::from)
+            .map_err(SchemaErrorKind::from)
+            .map_err(SchemaError::from)
             .map(Option::from)
-            .or_else(optional(None))?
+            .or_else(schema_optional(None))?
             .is_some()
         {
             return Ok(PropertyType::OneOf(SchemaOneOf::try_from(yaml)?));
@@ -139,8 +148,10 @@ impl<'schema> TryFrom<&'schema Yaml> for PropertyType<'schema> {
 
         if yaml
             .lookup("allOf", "hash", Option::from)
+            .map_err(SchemaErrorKind::from)
+            .map_err(SchemaError::from)
             .map(Option::from)
-            .or_else(optional(None))?
+            .or_else(schema_optional(None))?
             .is_some()
         {
             return Ok(PropertyType::AllOf(SchemaAllOf::try_from(yaml)?));
@@ -148,8 +159,10 @@ impl<'schema> TryFrom<&'schema Yaml> for PropertyType<'schema> {
 
         if yaml
             .lookup("anyOf", "hash", Option::from)
+            .map_err(SchemaErrorKind::from)
+            .map_err(SchemaError::from)
             .map(Option::from)
-            .or_else(optional(None))?
+            .or_else(schema_optional(None))?
             .is_some()
         {
             return Ok(PropertyType::AnyOf(SchemaAnyOf::try_from(yaml)?));

--- a/yaml-validator/src/lib.rs
+++ b/yaml-validator/src/lib.rs
@@ -6,15 +6,15 @@ pub use yaml_rust;
 use yaml_rust::Yaml;
 
 mod breadcrumb;
-mod error;
+mod errors;
 mod modifiers;
 mod types;
 mod utils;
 use modifiers::*;
 use types::*;
 
-use error::{add_path_name, condense_errors, optional};
-pub use error::{SchemaError, SchemaErrorKind};
+use errors::schema::{condense_errors, optional};
+pub use errors::schema::{SchemaError, SchemaErrorKind};
 
 use crate::types::bool::SchemaBool;
 use utils::YamlUtils;
@@ -207,7 +207,7 @@ impl<'schema> TryFrom<&'schema Yaml> for Schema<'schema> {
 
         let uri = yaml.lookup("uri", "string", Yaml::as_str)?;
         let schema = PropertyType::try_from(yaml.lookup("schema", "yaml", Option::from)?)
-            .map_err(add_path_name(uri))?;
+            .map_err(SchemaError::add_path_name(uri))?;
 
         Ok(Schema { uri, schema })
     }

--- a/yaml-validator/src/lib.rs
+++ b/yaml-validator/src/lib.rs
@@ -5,6 +5,7 @@ use std::convert::TryFrom;
 pub use yaml_rust;
 use yaml_rust::Yaml;
 
+mod breadcrumb;
 mod error;
 mod modifiers;
 mod types;

--- a/yaml-validator/src/lib.rs
+++ b/yaml-validator/src/lib.rs
@@ -14,13 +14,10 @@ use modifiers::*;
 use types::*;
 
 pub use errors::schema::{SchemaError, SchemaErrorKind};
-use errors::{
-    schema::{condense_schema_errors, schema_optional},
-    ValidationError,
-};
+use errors::{schema::condense_schema_errors, ValidationError};
 
 use crate::types::bool::SchemaBool;
-use utils::YamlUtils;
+use utils::{OptionalLookup, YamlUtils};
 
 /// Validation trait implemented by all types, as well as the [Schema](crate::Schema) type
 pub trait Validate<'yaml, 'schema: 'yaml> {
@@ -116,18 +113,16 @@ impl<'schema> TryFrom<&'schema Yaml> for PropertyType<'schema> {
 
         if let Some(uri) = yaml
             .lookup("$ref", "string", Yaml::as_str)
-            .map_err(SchemaError::from)
-            .map(Option::from)
-            .or_else(schema_optional(None))?
+            .into_optional()
+            .map_err(SchemaError::from)?
         {
             return Ok(PropertyType::Reference(SchemaReference { uri }));
         }
 
         if yaml
             .lookup("not", "hash", Option::from)
-            .map_err(SchemaError::from)
-            .map(Option::from)
-            .or_else(schema_optional(None))?
+            .into_optional()
+            .map_err(SchemaError::from)?
             .is_some()
         {
             return Ok(PropertyType::Not(SchemaNot::try_from(yaml)?));
@@ -135,9 +130,8 @@ impl<'schema> TryFrom<&'schema Yaml> for PropertyType<'schema> {
 
         if yaml
             .lookup("oneOf", "hash", Option::from)
-            .map_err(SchemaError::from)
-            .map(Option::from)
-            .or_else(schema_optional(None))?
+            .into_optional()
+            .map_err(SchemaError::from)?
             .is_some()
         {
             return Ok(PropertyType::OneOf(SchemaOneOf::try_from(yaml)?));
@@ -145,9 +139,8 @@ impl<'schema> TryFrom<&'schema Yaml> for PropertyType<'schema> {
 
         if yaml
             .lookup("allOf", "hash", Option::from)
-            .map_err(SchemaError::from)
-            .map(Option::from)
-            .or_else(schema_optional(None))?
+            .into_optional()
+            .map_err(SchemaError::from)?
             .is_some()
         {
             return Ok(PropertyType::AllOf(SchemaAllOf::try_from(yaml)?));
@@ -155,9 +148,8 @@ impl<'schema> TryFrom<&'schema Yaml> for PropertyType<'schema> {
 
         if yaml
             .lookup("anyOf", "hash", Option::from)
-            .map_err(SchemaError::from)
-            .map(Option::from)
-            .or_else(schema_optional(None))?
+            .into_optional()
+            .map_err(SchemaError::from)?
             .is_some()
         {
             return Ok(PropertyType::AnyOf(SchemaAnyOf::try_from(yaml)?));

--- a/yaml-validator/src/lib.rs
+++ b/yaml-validator/src/lib.rs
@@ -116,7 +116,6 @@ impl<'schema> TryFrom<&'schema Yaml> for PropertyType<'schema> {
 
         if let Some(uri) = yaml
             .lookup("$ref", "string", Yaml::as_str)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .map(Option::from)
             .or_else(schema_optional(None))?
@@ -126,7 +125,6 @@ impl<'schema> TryFrom<&'schema Yaml> for PropertyType<'schema> {
 
         if yaml
             .lookup("not", "hash", Option::from)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .map(Option::from)
             .or_else(schema_optional(None))?
@@ -137,7 +135,6 @@ impl<'schema> TryFrom<&'schema Yaml> for PropertyType<'schema> {
 
         if yaml
             .lookup("oneOf", "hash", Option::from)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .map(Option::from)
             .or_else(schema_optional(None))?
@@ -148,7 +145,6 @@ impl<'schema> TryFrom<&'schema Yaml> for PropertyType<'schema> {
 
         if yaml
             .lookup("allOf", "hash", Option::from)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .map(Option::from)
             .or_else(schema_optional(None))?
@@ -159,7 +155,6 @@ impl<'schema> TryFrom<&'schema Yaml> for PropertyType<'schema> {
 
         if yaml
             .lookup("anyOf", "hash", Option::from)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .map(Option::from)
             .or_else(schema_optional(None))?

--- a/yaml-validator/src/lib.rs
+++ b/yaml-validator/src/lib.rs
@@ -13,7 +13,7 @@ mod utils;
 use modifiers::*;
 use types::*;
 
-use errors::schema::{condense_errors, optional};
+use errors::{schema::{condense_errors, optional}, ValidationError};
 pub use errors::schema::{SchemaError, SchemaErrorKind};
 
 use crate::types::bool::SchemaBool;
@@ -25,7 +25,7 @@ pub trait Validate<'yaml, 'schema: 'yaml> {
         &self,
         ctx: &'schema Context<'schema>,
         yaml: &'yaml Yaml,
-    ) -> Result<(), SchemaError<'yaml>>;
+    ) -> Result<(), ValidationError<'yaml>>;
 }
 
 /// Contains a number of schemas that may or may not be dependent on each other.
@@ -175,7 +175,7 @@ impl<'yaml, 'schema: 'yaml> Validate<'yaml, 'schema> for PropertyType<'schema> {
         &self,
         ctx: &'schema Context<'schema>,
         yaml: &'yaml Yaml,
-    ) -> Result<(), SchemaError<'yaml>> {
+    ) -> Result<(), ValidationError<'yaml>> {
         match self {
             PropertyType::Integer(p) => p.validate(ctx, yaml),
             PropertyType::Real(p) => p.validate(ctx, yaml),
@@ -218,7 +218,7 @@ impl<'yaml, 'schema: 'yaml> Validate<'yaml, 'schema> for Schema<'schema> {
         &self,
         ctx: &'schema Context<'schema>,
         yaml: &'yaml Yaml,
-    ) -> Result<(), SchemaError<'yaml>> {
+    ) -> Result<(), ValidationError<'yaml>> {
         self.schema.validate(ctx, yaml)
     }
 }

--- a/yaml-validator/src/modifiers/all_of.rs
+++ b/yaml-validator/src/modifiers/all_of.rs
@@ -47,15 +47,14 @@ impl<'yaml, 'schema: 'yaml> Validate<'yaml, 'schema> for SchemaAllOf<'schema> {
         ctx: &'schema Context<'schema>,
         yaml: &'yaml Yaml,
     ) -> Result<(), ValidationError<'yaml>> {
-        let errs: Vec<_> = self
-            .items
-            .iter()
-            .enumerate()
-            .map(|(_, schema)| schema.validate(ctx, yaml))
-            .filter(Result::is_err)
-            .collect();
-
-        condense_validation_errors(&mut errs.into_iter())?;
+        condense_validation_errors(
+            &mut self
+                .items
+                .iter()
+                .enumerate()
+                .map(|(_, schema)| schema.validate(ctx, yaml))
+                .filter(Result::is_err),
+        )?;
         Ok(())
     }
 }

--- a/yaml-validator/src/modifiers/all_of.rs
+++ b/yaml-validator/src/modifiers/all_of.rs
@@ -15,11 +15,9 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaAllOf<'schema> {
     type Error = SchemaError<'schema>;
 
     fn try_from(yaml: &'schema Yaml) -> Result<Self, Self::Error> {
-        yaml.strict_contents(&["allOf"], &[])
-            .map_err(SchemaErrorKind::from)?;
+        yaml.strict_contents(&["allOf"], &[])?;
         let (items, errs): (Vec<_>, Vec<_>) = yaml
-            .lookup("allOf", "array", Yaml::as_vec)
-            .map_err(SchemaErrorKind::from)?
+            .lookup("allOf", "array", Yaml::as_vec)?
             .iter()
             .map(|property| {
                 PropertyType::try_from(property).map_err(SchemaError::add_path_name("items"))

--- a/yaml-validator/src/modifiers/all_of.rs
+++ b/yaml-validator/src/modifiers/all_of.rs
@@ -1,7 +1,6 @@
-use crate::errors::validation::condense_validation_errors;
 use crate::errors::ValidationError;
-use crate::errors::{schema::condense_schema_errors, SchemaError, SchemaErrorKind};
-use crate::utils::YamlUtils;
+use crate::errors::{SchemaError, SchemaErrorKind};
+use crate::utils::{CondenseErrors, YamlUtils};
 use crate::{Context, PropertyType, Validate};
 use std::convert::TryFrom;
 use yaml_rust::Yaml;
@@ -16,15 +15,14 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaAllOf<'schema> {
 
     fn try_from(yaml: &'schema Yaml) -> Result<Self, Self::Error> {
         yaml.strict_contents(&["allOf"], &[])?;
-        let (items, errs): (Vec<_>, Vec<_>) = yaml
-            .lookup("allOf", "array", Yaml::as_vec)?
-            .iter()
-            .map(|property| {
-                PropertyType::try_from(property).map_err(SchemaError::add_path_name("items"))
-            })
-            .partition(Result::is_ok);
-
-        condense_schema_errors(&mut errs.into_iter())?;
+        let items = SchemaError::condense_errors(
+            &mut yaml
+                .lookup("allOf", "array", Yaml::as_vec)?
+                .iter()
+                .map(|property| {
+                    PropertyType::try_from(property).map_err(SchemaError::add_path_name("items"))
+                }),
+        )?;
 
         if items.is_empty() {
             return Err(SchemaErrorKind::MalformedField {
@@ -33,9 +31,7 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaAllOf<'schema> {
             .with_path_name("allOf"));
         }
 
-        Ok(SchemaAllOf {
-            items: items.into_iter().map(Result::unwrap).collect(),
-        })
+        Ok(SchemaAllOf { items })
     }
 }
 
@@ -45,7 +41,7 @@ impl<'yaml, 'schema: 'yaml> Validate<'yaml, 'schema> for SchemaAllOf<'schema> {
         ctx: &'schema Context<'schema>,
         yaml: &'yaml Yaml,
     ) -> Result<(), ValidationError<'yaml>> {
-        condense_validation_errors(
+        ValidationError::condense_errors(
             &mut self
                 .items
                 .iter()

--- a/yaml-validator/src/modifiers/all_of.rs
+++ b/yaml-validator/src/modifiers/all_of.rs
@@ -1,4 +1,4 @@
-use crate::error::{add_path_name, condense_errors, SchemaError, SchemaErrorKind};
+use crate::errors::{schema::condense_errors, SchemaError, SchemaErrorKind};
 use crate::utils::YamlUtils;
 use crate::{Context, PropertyType, Validate};
 use std::convert::TryFrom;
@@ -17,7 +17,9 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaAllOf<'schema> {
         let (items, errs): (Vec<_>, Vec<_>) = yaml
             .lookup("allOf", "array", Yaml::as_vec)?
             .iter()
-            .map(|property| PropertyType::try_from(property).map_err(add_path_name("items")))
+            .map(|property| {
+                PropertyType::try_from(property).map_err(SchemaError::add_path_name("items"))
+            })
             .partition(Result::is_ok);
 
         condense_errors(&mut errs.into_iter())?;

--- a/yaml-validator/src/modifiers/any_of.rs
+++ b/yaml-validator/src/modifiers/any_of.rs
@@ -15,11 +15,9 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaAnyOf<'schema> {
     type Error = SchemaError<'schema>;
 
     fn try_from(yaml: &'schema Yaml) -> Result<Self, Self::Error> {
-        yaml.strict_contents(&["anyOf"], &[])
-            .map_err(SchemaErrorKind::from)?;
+        yaml.strict_contents(&["anyOf"], &[])?;
         let (items, errs): (Vec<_>, Vec<_>) = yaml
-            .lookup("anyOf", "array", Yaml::as_vec)
-            .map_err(SchemaErrorKind::from)?
+            .lookup("anyOf", "array", Yaml::as_vec)?
             .iter()
             .map(|property| {
                 PropertyType::try_from(property).map_err(SchemaError::add_path_name("items"))

--- a/yaml-validator/src/modifiers/any_of.rs
+++ b/yaml-validator/src/modifiers/any_of.rs
@@ -1,4 +1,6 @@
-use crate::errors::{schema::condense_errors, SchemaError, SchemaErrorKind};
+use crate::errors::validation::condense_validation_errors;
+use crate::errors::ValidationError;
+use crate::errors::{schema::condense_schema_errors, SchemaError, SchemaErrorKind};
 use crate::utils::YamlUtils;
 use crate::{Context, PropertyType, Validate};
 use std::convert::TryFrom;
@@ -13,16 +15,18 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaAnyOf<'schema> {
     type Error = SchemaError<'schema>;
 
     fn try_from(yaml: &'schema Yaml) -> Result<Self, Self::Error> {
-        yaml.strict_contents(&["anyOf"], &[])?;
+        yaml.strict_contents(&["anyOf"], &[])
+            .map_err(SchemaErrorKind::from)?;
         let (items, errs): (Vec<_>, Vec<_>) = yaml
-            .lookup("anyOf", "array", Yaml::as_vec)?
+            .lookup("anyOf", "array", Yaml::as_vec)
+            .map_err(SchemaErrorKind::from)?
             .iter()
             .map(|property| {
                 PropertyType::try_from(property).map_err(SchemaError::add_path_name("items"))
             })
             .partition(Result::is_ok);
 
-        condense_errors(&mut errs.into_iter())?;
+        condense_schema_errors(&mut errs.into_iter())?;
 
         if items.is_empty() {
             return Err(SchemaErrorKind::MalformedField {
@@ -42,7 +46,7 @@ impl<'yaml, 'schema: 'yaml> Validate<'yaml, 'schema> for SchemaAnyOf<'schema> {
         &self,
         ctx: &'schema Context<'schema>,
         yaml: &'yaml Yaml,
-    ) -> Result<(), SchemaError<'yaml>> {
+    ) -> Result<(), ValidationError<'yaml>> {
         let (valid, errs): (Vec<_>, Vec<_>) = self
             .items
             .iter()
@@ -51,7 +55,7 @@ impl<'yaml, 'schema: 'yaml> Validate<'yaml, 'schema> for SchemaAnyOf<'schema> {
             .partition(Result::is_ok);
 
         if valid.is_empty() {
-            Err(condense_errors(&mut errs.into_iter()).unwrap_err())
+            Err(condense_validation_errors(&mut errs.into_iter()).unwrap_err())
         } else {
             Ok(())
         }

--- a/yaml-validator/src/modifiers/any_of.rs
+++ b/yaml-validator/src/modifiers/any_of.rs
@@ -1,4 +1,4 @@
-use crate::error::{add_path_name, condense_errors, SchemaError, SchemaErrorKind};
+use crate::errors::{schema::condense_errors, SchemaError, SchemaErrorKind};
 use crate::utils::YamlUtils;
 use crate::{Context, PropertyType, Validate};
 use std::convert::TryFrom;
@@ -17,7 +17,9 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaAnyOf<'schema> {
         let (items, errs): (Vec<_>, Vec<_>) = yaml
             .lookup("anyOf", "array", Yaml::as_vec)?
             .iter()
-            .map(|property| PropertyType::try_from(property).map_err(add_path_name("items")))
+            .map(|property| {
+                PropertyType::try_from(property).map_err(SchemaError::add_path_name("items"))
+            })
             .partition(Result::is_ok);
 
         condense_errors(&mut errs.into_iter())?;

--- a/yaml-validator/src/modifiers/not.rs
+++ b/yaml-validator/src/modifiers/not.rs
@@ -1,6 +1,6 @@
 use crate::errors::{SchemaError, ValidationError, ValidationErrorKind};
 use crate::utils::YamlUtils;
-use crate::{Context, PropertyType, SchemaErrorKind, Validate};
+use crate::{Context, PropertyType, Validate};
 use std::convert::TryFrom;
 use yaml_rust::Yaml;
 
@@ -12,18 +12,15 @@ pub(crate) struct SchemaNot<'schema> {
 impl<'schema> TryFrom<&'schema Yaml> for SchemaNot<'schema> {
     type Error = SchemaError<'schema>;
     fn try_from(yaml: &'schema Yaml) -> Result<Self, Self::Error> {
-        yaml.strict_contents(&["not"], &[])
-            .map_err(SchemaErrorKind::from)?;
+        yaml.strict_contents(&["not"], &[])?;
 
         // I'm using Option::from here because I don't actually want to transform
         // the resulting yaml object into a specific type, but need the yaml itself
         // to be passed into PropertyType::try_from
         yaml.lookup("not", "yaml", Option::from)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .map(|inner| {
                 yaml.lookup("not", "hash", Yaml::as_hash)
-                    .map_err(SchemaErrorKind::from)
                     .map_err(SchemaError::from)
                     .map_err(SchemaError::add_path_name("not"))?;
                 Ok(SchemaNot {

--- a/yaml-validator/src/modifiers/not.rs
+++ b/yaml-validator/src/modifiers/not.rs
@@ -1,4 +1,4 @@
-use crate::error::{add_path_name, SchemaError, SchemaErrorKind};
+use crate::errors::{SchemaError, SchemaErrorKind};
 use crate::utils::YamlUtils;
 use crate::{Context, PropertyType, Validate};
 use std::convert::TryFrom;
@@ -19,9 +19,11 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaNot<'schema> {
         // to be passed into PropertyType::try_from
         yaml.lookup("not", "yaml", Option::from).map(|inner| {
             yaml.lookup("not", "hash", Yaml::as_hash)
-                .map_err(add_path_name("not"))?;
+                .map_err(SchemaError::add_path_name("not"))?;
             Ok(SchemaNot {
-                item: Box::new(PropertyType::try_from(inner).map_err(add_path_name("not"))?),
+                item: Box::new(
+                    PropertyType::try_from(inner).map_err(SchemaError::add_path_name("not"))?,
+                ),
             })
         })?
     }

--- a/yaml-validator/src/modifiers/one_of.rs
+++ b/yaml-validator/src/modifiers/one_of.rs
@@ -15,11 +15,9 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaOneOf<'schema> {
     type Error = SchemaError<'schema>;
 
     fn try_from(yaml: &'schema Yaml) -> Result<Self, Self::Error> {
-        yaml.strict_contents(&["oneOf"], &[])
-            .map_err(SchemaErrorKind::from)?;
+        yaml.strict_contents(&["oneOf"], &[])?;
         let (items, errs): (Vec<_>, Vec<_>) = yaml
-            .lookup("oneOf", "array", Yaml::as_vec)
-            .map_err(SchemaErrorKind::from)?
+            .lookup("oneOf", "array", Yaml::as_vec)?
             .iter()
             .map(|property| {
                 PropertyType::try_from(property).map_err(SchemaError::add_path_name("items"))

--- a/yaml-validator/src/modifiers/one_of.rs
+++ b/yaml-validator/src/modifiers/one_of.rs
@@ -1,4 +1,4 @@
-use crate::error::{add_path_name, condense_errors, SchemaError, SchemaErrorKind};
+use crate::errors::{schema::condense_errors, SchemaError, SchemaErrorKind};
 use crate::utils::YamlUtils;
 use crate::{Context, PropertyType, Validate};
 use std::convert::TryFrom;
@@ -17,7 +17,9 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaOneOf<'schema> {
         let (items, errs): (Vec<_>, Vec<_>) = yaml
             .lookup("oneOf", "array", Yaml::as_vec)?
             .iter()
-            .map(|property| PropertyType::try_from(property).map_err(add_path_name("items")))
+            .map(|property| {
+                PropertyType::try_from(property).map_err(SchemaError::add_path_name("items"))
+            })
             .partition(Result::is_ok);
 
         condense_errors(&mut errs.into_iter())?;

--- a/yaml-validator/src/types/array.rs
+++ b/yaml-validator/src/types/array.rs
@@ -33,12 +33,10 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaArray<'schema> {
                 "minContains",
                 "maxContains",
             ],
-        )
-        .map_err(SchemaErrorKind::from)?;
+        )?;
 
         let min_items = yaml
             .lookup("minItems", "integer", Yaml::as_i64)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .and_then(try_into_usize)
             .map_err(SchemaError::add_path_name("minItems"))
@@ -47,7 +45,6 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaArray<'schema> {
 
         let max_items = yaml
             .lookup("maxItems", "integer", Yaml::as_i64)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .and_then(try_into_usize)
             .map_err(SchemaError::add_path_name("maxItems"))
@@ -56,7 +53,6 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaArray<'schema> {
 
         let unique_items = yaml
             .lookup("uniqueItems", "bool", Yaml::as_bool)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .map_err(SchemaError::add_path_name("uniqueItems"))
             .map(Option::from)
@@ -74,7 +70,6 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaArray<'schema> {
 
         let items = yaml
             .lookup("items", "yaml", Option::from)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .map_err(SchemaError::add_path_name("items"))
             .map(Option::from)
@@ -86,7 +81,6 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaArray<'schema> {
 
         let contains = yaml
             .lookup("contains", "yaml", Option::from)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .map_err(SchemaError::add_path_name("contains"))
             .map(Option::from)
@@ -98,7 +92,6 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaArray<'schema> {
 
         let min_contains = yaml
             .lookup("minContains", "integer", Yaml::as_i64)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .and_then(try_into_usize)
             .map_err(SchemaError::add_path_name("minContains"))
@@ -107,7 +100,6 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaArray<'schema> {
 
         let max_contains = yaml
             .lookup("maxContains", "integer", Yaml::as_i64)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .and_then(try_into_usize)
             .map_err(SchemaError::add_path_name("maxContains"))
@@ -155,9 +147,7 @@ impl<'yaml, 'schema: 'yaml> Validate<'yaml, 'schema> for SchemaArray<'schema> {
         ctx: &'schema Context<'schema>,
         yaml: &'yaml Yaml,
     ) -> Result<(), ValidationError<'yaml>> {
-        let items = yaml
-            .as_type("array", Yaml::as_vec)
-            .map_err(ValidationErrorKind::from)?;
+        let items = yaml.as_type("array", Yaml::as_vec)?;
 
         if let Some(min_items) = &self.min_items {
             if items.len() < *min_items {

--- a/yaml-validator/src/types/array.rs
+++ b/yaml-validator/src/types/array.rs
@@ -1,7 +1,6 @@
-use crate::errors::validation::condense_validation_errors;
 use crate::errors::{SchemaError, SchemaErrorKind};
 use crate::errors::{ValidationError, ValidationErrorKind};
-use crate::utils::{try_into_usize, OptionalLookup, YamlUtils};
+use crate::utils::{try_into_usize, CondenseErrors, OptionalLookup, YamlUtils};
 use crate::{Context, PropertyType, Validate};
 use std::collections::HashSet;
 use std::convert::TryFrom;
@@ -218,7 +217,7 @@ impl<'yaml, 'schema: 'yaml> Validate<'yaml, 'schema> for SchemaArray<'schema> {
                     .map_err(ValidationError::add_path_index(i))
             });
 
-            condense_validation_errors(&mut errors)?;
+            ValidationError::condense_errors(&mut errors)?;
         }
 
         Ok(())

--- a/yaml-validator/src/types/bool.rs
+++ b/yaml-validator/src/types/bool.rs
@@ -1,4 +1,4 @@
-use crate::error::SchemaError;
+use crate::errors::SchemaError;
 use crate::utils::YamlUtils;
 use crate::{Context, Validate};
 use std::convert::TryFrom;
@@ -30,7 +30,7 @@ impl<'yaml, 'schema: 'yaml> Validate<'yaml, 'schema> for SchemaBool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::SchemaErrorKind;
+    use crate::errors::SchemaErrorKind;
     use crate::types::SchemaInteger;
     use crate::utils::load_simple;
     use crate::SchemaString;

--- a/yaml-validator/src/types/bool.rs
+++ b/yaml-validator/src/types/bool.rs
@@ -1,6 +1,6 @@
-use crate::errors::{SchemaError, ValidationError, ValidationErrorKind};
+use crate::errors::{SchemaError, ValidationError};
 use crate::utils::YamlUtils;
-use crate::{Context, SchemaErrorKind, Validate};
+use crate::{Context, Validate};
 use std::convert::TryFrom;
 use yaml_rust::Yaml;
 
@@ -10,8 +10,7 @@ pub(crate) struct SchemaBool {}
 impl<'schema> TryFrom<&'schema Yaml> for SchemaBool {
     type Error = SchemaError<'schema>;
     fn try_from(yaml: &'schema Yaml) -> Result<Self, Self::Error> {
-        yaml.strict_contents(&[], &["type"])
-            .map_err(SchemaErrorKind::from)?;
+        yaml.strict_contents(&[], &["type"])?;
         Ok(SchemaBool {})
     }
 }
@@ -22,9 +21,7 @@ impl<'yaml, 'schema: 'yaml> Validate<'yaml, 'schema> for SchemaBool {
         _: &'schema Context<'schema>,
         yaml: &'yaml Yaml,
     ) -> Result<(), ValidationError<'yaml>> {
-        let _value = yaml
-            .as_type("bool", Yaml::as_bool)
-            .map_err(ValidationErrorKind::from)?;
+        let _value = yaml.as_type("bool", Yaml::as_bool)?;
 
         Ok(())
     }

--- a/yaml-validator/src/types/hash.rs
+++ b/yaml-validator/src/types/hash.rs
@@ -1,6 +1,6 @@
-use crate::errors::{schema::schema_optional, SchemaError};
+use crate::errors::SchemaError;
 use crate::errors::{ValidationError, ValidationErrorKind};
-use crate::utils::YamlUtils;
+use crate::utils::{OptionalLookup, YamlUtils};
 use crate::{Context, PropertyType, Validate};
 use std::convert::TryFrom;
 use yaml_rust::Yaml;
@@ -32,7 +32,8 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaHash<'schema> {
                     )),
                 })
             })
-            .or_else(schema_optional(Ok(SchemaHash { items: None })))?
+            .into_optional()?
+            .unwrap_or(Ok(SchemaHash { items: None }))
     }
 }
 

--- a/yaml-validator/src/types/integer.rs
+++ b/yaml-validator/src/types/integer.rs
@@ -62,7 +62,7 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaInteger {
                 .or_else(schema_optional(None))?);
 
         if let (Some(lower), Some(upper)) = (&minimum, &maximum) {
-            if !lower.has_span(&upper) {
+            if !lower.has_span(upper) {
                 return Err(SchemaErrorKind::MalformedField {
                     error: "range given for real value spans 0 possible values".into(),
                 }

--- a/yaml-validator/src/types/integer.rs
+++ b/yaml-validator/src/types/integer.rs
@@ -1,6 +1,6 @@
-use crate::errors::{schema::schema_optional, SchemaError, SchemaErrorKind};
+use crate::errors::{SchemaError, SchemaErrorKind};
 use crate::errors::{ValidationError, ValidationErrorKind};
-use crate::utils::{Limit, YamlUtils};
+use crate::utils::{Limit, OptionalLookup, YamlUtils};
 use crate::{Context, Validate};
 use std::convert::TryFrom;
 use yaml_rust::Yaml;
@@ -34,27 +34,23 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaInteger {
             .lookup("minimum", "integer", Yaml::as_i64)
             .map_err(SchemaError::from)
             .map(Limit::Inclusive)
-            .map(Option::from)
-            .or_else(schema_optional(None))?
+            .into_optional()?
             .or(yaml
                 .lookup("exclusiveMinimum", "integer", Yaml::as_i64)
                 .map_err(SchemaError::from)
                 .map(Limit::Exclusive)
-                .map(Option::from)
-                .or_else(schema_optional(None))?);
+                .into_optional()?);
 
         let maximum = yaml
             .lookup("maximum", "integer", Yaml::as_i64)
             .map_err(SchemaError::from)
             .map(Limit::Inclusive)
-            .map(Option::from)
-            .or_else(schema_optional(None))?
+            .into_optional()?
             .or(yaml
                 .lookup("exclusiveMaximum", "integer", Yaml::as_i64)
                 .map_err(SchemaError::from)
                 .map(Limit::Exclusive)
-                .map(Option::from)
-                .or_else(schema_optional(None))?);
+                .into_optional()?);
 
         if let (Some(lower), Some(upper)) = (&minimum, &maximum) {
             if !lower.has_span(upper) {
@@ -78,8 +74,7 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaInteger {
                     Ok(number)
                 }
             })
-            .map(Option::from)
-            .or_else(schema_optional(None))?;
+            .into_optional()?;
 
         Ok(SchemaInteger {
             minimum,

--- a/yaml-validator/src/types/integer.rs
+++ b/yaml-validator/src/types/integer.rs
@@ -1,4 +1,4 @@
-use crate::error::{optional, SchemaError, SchemaErrorKind};
+use crate::errors::{schema::optional, SchemaError, SchemaErrorKind};
 use crate::utils::{Limit, YamlUtils};
 use crate::{Context, Validate};
 use std::convert::TryFrom;

--- a/yaml-validator/src/types/integer.rs
+++ b/yaml-validator/src/types/integer.rs
@@ -25,22 +25,19 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaInteger {
                 "exclusiveMaximum",
                 "multipleOf",
             ],
-        )
-        .map_err(SchemaErrorKind::from)?;
+        )?;
 
         yaml.check_exclusive_fields(&["minimum", "exclusiveMinimum"])?;
         yaml.check_exclusive_fields(&["maximum", "exclusiveMaximum"])?;
 
         let minimum = yaml
             .lookup("minimum", "integer", Yaml::as_i64)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .map(Limit::Inclusive)
             .map(Option::from)
             .or_else(schema_optional(None))?
             .or(yaml
                 .lookup("exclusiveMinimum", "integer", Yaml::as_i64)
-                .map_err(SchemaErrorKind::from)
                 .map_err(SchemaError::from)
                 .map(Limit::Exclusive)
                 .map(Option::from)
@@ -48,14 +45,12 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaInteger {
 
         let maximum = yaml
             .lookup("maximum", "integer", Yaml::as_i64)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .map(Limit::Inclusive)
             .map(Option::from)
             .or_else(schema_optional(None))?
             .or(yaml
                 .lookup("exclusiveMaximum", "integer", Yaml::as_i64)
-                .map_err(SchemaErrorKind::from)
                 .map_err(SchemaError::from)
                 .map(Limit::Exclusive)
                 .map(Option::from)
@@ -72,7 +67,6 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaInteger {
 
         let multiple_of = yaml
             .lookup("multipleOf", "integer", Yaml::as_i64)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .and_then(|number| {
                 if number <= 0 {
@@ -101,9 +95,7 @@ impl<'yaml, 'schema: 'yaml> Validate<'yaml, 'schema> for SchemaInteger {
         _: &'schema Context<'schema>,
         yaml: &'yaml Yaml,
     ) -> Result<(), ValidationError<'yaml>> {
-        let value = yaml
-            .as_type("integer", Yaml::as_i64)
-            .map_err(ValidationErrorKind::from)?;
+        let value = yaml.as_type("integer", Yaml::as_i64)?;
 
         if let Some(minimum) = &self.minimum {
             if !minimum.is_greater(&value) {

--- a/yaml-validator/src/types/object.rs
+++ b/yaml-validator/src/types/object.rs
@@ -140,7 +140,7 @@ mod tests {
                 expected: "hash",
                 actual: "string"
             }
-            .with_path(path!["hello", "items"]),
+            .with_path(breadcrumb!["hello", "items"]),
         );
     }
 
@@ -164,11 +164,11 @@ mod tests {
                     SchemaErrorKind::UnknownType {
                         unknown_type: "unknown1"
                     }
-                    .with_path(path!["error 1", "items"]),
+                    .with_path(breadcrumb!["error 1", "items"]),
                     SchemaErrorKind::UnknownType {
                         unknown_type: "unknown2"
                     }
-                    .with_path(path!["error 2", "items"]),
+                    .with_path(breadcrumb!["error 2", "items"]),
                 ]
             }
             .into()

--- a/yaml-validator/src/types/real.rs
+++ b/yaml-validator/src/types/real.rs
@@ -1,6 +1,6 @@
-use crate::errors::{schema::schema_optional, SchemaError, SchemaErrorKind};
+use crate::errors::{SchemaError, SchemaErrorKind};
 use crate::errors::{ValidationError, ValidationErrorKind};
-use crate::utils::{Limit, YamlUtils};
+use crate::utils::{Limit, OptionalLookup, YamlUtils};
 use crate::{Context, Validate};
 use std::convert::TryFrom;
 use yaml_rust::Yaml;
@@ -34,27 +34,23 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaReal {
             .lookup("minimum", "real", Yaml::as_f64)
             .map_err(SchemaError::from)
             .map(Limit::Inclusive)
-            .map(Option::from)
-            .or_else(schema_optional(None))?
+            .into_optional()?
             .or(yaml
                 .lookup("exclusiveMinimum", "real", Yaml::as_f64)
                 .map_err(SchemaError::from)
                 .map(Limit::Exclusive)
-                .map(Option::from)
-                .or_else(schema_optional(None))?);
+                .into_optional()?);
 
         let maximum = yaml
             .lookup("maximum", "real", Yaml::as_f64)
             .map_err(SchemaError::from)
             .map(Limit::Inclusive)
-            .map(Option::from)
-            .or_else(schema_optional(None))?
+            .into_optional()?
             .or(yaml
                 .lookup("exclusiveMaximum", "real", Yaml::as_f64)
                 .map_err(SchemaError::from)
                 .map(Limit::Exclusive)
-                .map(Option::from)
-                .or_else(schema_optional(None))?);
+                .into_optional()?);
 
         let multiple_of = yaml
             .lookup("multipleOf", "real", Yaml::as_f64)
@@ -69,8 +65,7 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaReal {
                     Ok(number)
                 }
             })
-            .map(Option::from)
-            .or_else(schema_optional(None))?;
+            .into_optional()?;
 
         if let (Some(lower), Some(upper)) = (&minimum, &maximum) {
             if !lower.has_span(upper) {

--- a/yaml-validator/src/types/real.rs
+++ b/yaml-validator/src/types/real.rs
@@ -78,7 +78,7 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaReal {
             .or_else(schema_optional(None))?;
 
         if let (Some(lower), Some(upper)) = (&minimum, &maximum) {
-            if !lower.has_span(&upper) {
+            if !lower.has_span(upper) {
                 return Err(SchemaErrorKind::MalformedField {
                     error: "range given for real value spans 0 possible values".into(),
                 }

--- a/yaml-validator/src/types/real.rs
+++ b/yaml-validator/src/types/real.rs
@@ -1,4 +1,4 @@
-use crate::error::{optional, SchemaError, SchemaErrorKind};
+use crate::errors::{schema::optional, SchemaError, SchemaErrorKind};
 use crate::utils::{Limit, YamlUtils};
 use crate::{Context, Validate};
 use std::convert::TryFrom;

--- a/yaml-validator/src/types/real.rs
+++ b/yaml-validator/src/types/real.rs
@@ -32,14 +32,12 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaReal {
 
         let minimum = yaml
             .lookup("minimum", "real", Yaml::as_f64)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .map(Limit::Inclusive)
             .map(Option::from)
             .or_else(schema_optional(None))?
             .or(yaml
                 .lookup("exclusiveMinimum", "real", Yaml::as_f64)
-                .map_err(SchemaErrorKind::from)
                 .map_err(SchemaError::from)
                 .map(Limit::Exclusive)
                 .map(Option::from)
@@ -47,14 +45,12 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaReal {
 
         let maximum = yaml
             .lookup("maximum", "real", Yaml::as_f64)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .map(Limit::Inclusive)
             .map(Option::from)
             .or_else(schema_optional(None))?
             .or(yaml
                 .lookup("exclusiveMaximum", "real", Yaml::as_f64)
-                .map_err(SchemaErrorKind::from)
                 .map_err(SchemaError::from)
                 .map(Limit::Exclusive)
                 .map(Option::from)
@@ -62,7 +58,6 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaReal {
 
         let multiple_of = yaml
             .lookup("multipleOf", "real", Yaml::as_f64)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .and_then(|number| {
                 if number <= 0.0 {

--- a/yaml-validator/src/types/reference.rs
+++ b/yaml-validator/src/types/reference.rs
@@ -33,7 +33,7 @@ mod tests {
             SchemaReference { uri: "test" }
                 .validate(&Context::default(), &load_simple("hello"))
                 .unwrap_err(),
-                ValidationErrorKind::UnknownSchema { uri: "test" }.into()
+            ValidationErrorKind::UnknownSchema { uri: "test" }.into()
         );
     }
 }

--- a/yaml-validator/src/types/reference.rs
+++ b/yaml-validator/src/types/reference.rs
@@ -1,4 +1,4 @@
-use crate::error::{SchemaError, SchemaErrorKind};
+use crate::errors::{SchemaError, SchemaErrorKind};
 use crate::{Context, Validate};
 use yaml_rust::Yaml;
 

--- a/yaml-validator/src/types/reference.rs
+++ b/yaml-validator/src/types/reference.rs
@@ -1,4 +1,4 @@
-use crate::errors::{SchemaError, SchemaErrorKind};
+use crate::errors::{ValidationError, ValidationErrorKind};
 use crate::{Context, Validate};
 use yaml_rust::Yaml;
 
@@ -12,11 +12,11 @@ impl<'yaml, 'schema: 'yaml> Validate<'yaml, 'schema> for SchemaReference<'schema
         &self,
         ctx: &'schema Context<'schema>,
         yaml: &'yaml Yaml,
-    ) -> Result<(), SchemaError<'yaml>> {
+    ) -> Result<(), ValidationError<'yaml>> {
         if let Some(schema) = ctx.get_schema(self.uri) {
             schema.validate(ctx, yaml)
         } else {
-            Err(SchemaErrorKind::UnknownSchema { uri: self.uri }.into())
+            Err(ValidationErrorKind::UnknownSchema { uri: self.uri }.into())
         }
     }
 }
@@ -33,7 +33,7 @@ mod tests {
             SchemaReference { uri: "test" }
                 .validate(&Context::default(), &load_simple("hello"))
                 .unwrap_err(),
-            SchemaErrorKind::UnknownSchema { uri: "test" }.into()
+                ValidationErrorKind::UnknownSchema { uri: "test" }.into()
         );
     }
 }

--- a/yaml-validator/src/types/string.rs
+++ b/yaml-validator/src/types/string.rs
@@ -28,7 +28,6 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaString {
 
         let min_length = yaml
             .lookup("minLength", "integer", Yaml::as_i64)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .and_then(try_into_usize)
             .map_err(SchemaError::add_path_name("minLength"))
@@ -37,7 +36,6 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaString {
 
         let max_length = yaml
             .lookup("maxLength", "integer", Yaml::as_i64)
-            .map_err(SchemaErrorKind::from)
             .map_err(SchemaError::from)
             .and_then(try_into_usize)
             .map_err(SchemaError::add_path_name("maxLength"))
@@ -57,7 +55,6 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaString {
         {
             let pattern = yaml
                 .lookup("pattern", "string", Yaml::as_str)
-                .map_err(SchemaErrorKind::from)
                 .map_err(SchemaError::from)
                 .map(Option::from)
                 .or_else(schema_optional(None))?

--- a/yaml-validator/src/types/string.rs
+++ b/yaml-validator/src/types/string.rs
@@ -1,4 +1,4 @@
-use crate::error::{add_path_name, optional, SchemaError, SchemaErrorKind};
+use crate::errors::{schema::optional, SchemaError, SchemaErrorKind};
 use crate::utils::{try_into_usize, YamlUtils};
 use crate::{Context, Validate};
 use std::convert::TryFrom;
@@ -28,14 +28,14 @@ impl<'schema> TryFrom<&'schema Yaml> for SchemaString {
         let min_length = yaml
             .lookup("minLength", "integer", Yaml::as_i64)
             .and_then(try_into_usize)
-            .map_err(add_path_name("minLength"))
+            .map_err(SchemaError::add_path_name("minLength"))
             .map(Option::from)
             .or_else(optional(None))?;
 
         let max_length = yaml
             .lookup("maxLength", "integer", Yaml::as_i64)
             .and_then(try_into_usize)
-            .map_err(add_path_name("maxLength"))
+            .map_err(SchemaError::add_path_name("maxLength"))
             .map(Option::from)
             .or_else(optional(None))?;
 
@@ -124,7 +124,7 @@ impl<'yaml, 'schema: 'yaml> Validate<'yaml, 'schema> for SchemaString {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::SchemaErrorKind;
+    use crate::errors::SchemaErrorKind;
     use crate::utils::load_simple;
     use crate::SchemaString;
 

--- a/yaml-validator/src/utils.rs
+++ b/yaml-validator/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::error::{SchemaError, SchemaErrorKind};
+use crate::errors::{SchemaError, SchemaErrorKind};
 use std::convert::TryInto;
 use std::fmt::Display;
 use std::ops::{Index, Sub};

--- a/yaml-validator/src/utils.rs
+++ b/yaml-validator/src/utils.rs
@@ -188,9 +188,7 @@ impl YamlUtils for Yaml {
         &'schema self,
         exclusive_keys: &[&'static str],
     ) -> Result<(), SchemaError<'schema>> {
-        let hash = self
-            .as_type("hash", Yaml::as_hash)
-            .map_err(SchemaErrorKind::from)?;
+        let hash = self.as_type("hash", Yaml::as_hash)?;
 
         let conflicts: Vec<&'static str> = exclusive_keys
             .iter()


### PR DESCRIPTION
I have a feeling these might re-converge if we start dog-fooding and using schemas for validating our own schemas when building Schemas from yaml, but until then, this is a much better way of doing it. There's a bunch of duplication in this code still, but it's a working WIP.

Adds a Breadcrumb struct for keeping track of paths deep in a call tree.

This is the first step towards solving #32 

